### PR TITLE
Fix installation instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A simple command line application to find unicode characters with minimum effort
 Installation
 ===
 
-`cargo install fu`
+`cargo install find_unicode`
 
 Usage
 ===


### PR DESCRIPTION
`cargo install fu` doesn't work because the package name is `find_unicode` 🙂 